### PR TITLE
Add site instructions on main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Global Website Example
+
+이 저장소는 전세계 어디서든 접속할 수 있는 간단한 정적 웹사이트 예제를 제공합니다.
+
+## 파일
+
+- `index.html` - 메인 웹 페이지 파일입니다.
+- `aa.html` - `index.html`로 리다이렉트되는 예제 파일입니다.
+
+## 사용 방법
+
+1. 이 저장소를 클론합니다.
+2. `index.html` 파일을 원하는 콘텐츠로 수정합니다.
+3. `main` 브랜치에 `index.html`이 존재하는지 확인합니다.
+4. GitHub Pages 설정 화면에서 배포 브랜치(Source)를 `main`으로 지정합니다.
+   (필요하면 `index.html`이 있는 다른 브랜치를 선택할 수 있습니다.)
+
+### GitHub Pages 배포 예시
+
+```bash
+# 저장소를 GitHub에 업로드한 후
+# 메인 브랜치를 기준으로 GitHub Pages를 설정합니다.
+# 브라우저에서 https://<사용자이름>.github.io/<저장소이름>/ 로 접속하여 사이트를 확인할 수 있습니다.
+```
+
+이 외에도 Vercel, Netlify, AWS 등의 다양한 호스팅 방법을 사용할 수 있습니다.

--- a/aa.html
+++ b/aa.html
@@ -1,1 +1,10 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=index.html">
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>Redirecting to <a href="index.html">index.html</a>...</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to the Global Site</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
+        h1 { color: #2c3e50; }
+        p { color: #555; }
+    </style>
+</head>
+<body>
+    <h1>전세계 어디서든 접속 가능한 사이트</h1>
+    <p>이 페이지는 간단한 정적 웹사이트 예제입니다.</p>
+    <p>여기에 원하는 콘텐츠를 추가하여 글로벌 웹사이트를 만들어 보세요.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- merge example website into `main`
- clarify README to specify GitHub Pages should deploy from `main`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6840ab65c5048325b6bad7877899b013